### PR TITLE
us-167 Prettier für TailwindCSS hinzufügen

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,7 +9,7 @@ const config = {
     htmlWhitespaceSensitivity: "css",
 
     // plugins and settings for file types
-    plugins: ["prettier-plugin-svelte"],
+    plugins: ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
     overrides: [
         { files: "*.svelte", options: { parser: "svelte" } },
         { files: "*.svg", options: { parser: "html" } },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "postcss": "8.4.38",
                 "prettier": "^3.1.1",
                 "prettier-plugin-svelte": "^3.1.2",
+                "prettier-plugin-tailwindcss": "^0.6.5",
                 "svelte": "^4.2.7",
                 "tailwindcss": "3.4.4",
                 "vite": "^5.0.3",
@@ -2962,6 +2963,80 @@
             "peerDependencies": {
                 "prettier": "^3.0.0",
                 "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+            }
+        },
+        "node_modules/prettier-plugin-tailwindcss": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.5.tgz",
+            "integrity": "sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.21.3"
+            },
+            "peerDependencies": {
+                "@ianvs/prettier-plugin-sort-imports": "*",
+                "@prettier/plugin-pug": "*",
+                "@shopify/prettier-plugin-liquid": "*",
+                "@trivago/prettier-plugin-sort-imports": "*",
+                "@zackad/prettier-plugin-twig-melody": "*",
+                "prettier": "^3.0",
+                "prettier-plugin-astro": "*",
+                "prettier-plugin-css-order": "*",
+                "prettier-plugin-import-sort": "*",
+                "prettier-plugin-jsdoc": "*",
+                "prettier-plugin-marko": "*",
+                "prettier-plugin-organize-attributes": "*",
+                "prettier-plugin-organize-imports": "*",
+                "prettier-plugin-sort-imports": "*",
+                "prettier-plugin-style-order": "*",
+                "prettier-plugin-svelte": "*"
+            },
+            "peerDependenciesMeta": {
+                "@ianvs/prettier-plugin-sort-imports": {
+                    "optional": true
+                },
+                "@prettier/plugin-pug": {
+                    "optional": true
+                },
+                "@shopify/prettier-plugin-liquid": {
+                    "optional": true
+                },
+                "@trivago/prettier-plugin-sort-imports": {
+                    "optional": true
+                },
+                "@zackad/prettier-plugin-twig-melody": {
+                    "optional": true
+                },
+                "prettier-plugin-astro": {
+                    "optional": true
+                },
+                "prettier-plugin-css-order": {
+                    "optional": true
+                },
+                "prettier-plugin-import-sort": {
+                    "optional": true
+                },
+                "prettier-plugin-jsdoc": {
+                    "optional": true
+                },
+                "prettier-plugin-marko": {
+                    "optional": true
+                },
+                "prettier-plugin-organize-attributes": {
+                    "optional": true
+                },
+                "prettier-plugin-organize-imports": {
+                    "optional": true
+                },
+                "prettier-plugin-sort-imports": {
+                    "optional": true
+                },
+                "prettier-plugin-style-order": {
+                    "optional": true
+                },
+                "prettier-plugin-svelte": {
+                    "optional": true
+                }
             }
         },
         "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "postcss": "8.4.38",
         "prettier": "^3.1.1",
         "prettier-plugin-svelte": "^3.1.2",
+        "prettier-plugin-tailwindcss": "^0.6.5",
         "svelte": "^4.2.7",
         "tailwindcss": "3.4.4",
         "vite": "^5.0.3",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -71,7 +71,7 @@
                 <img
                     src="/logo-full-white.svg"
                     alt="logo"
-                    class="scale-50 w-500"
+                    class="w-500 scale-50"
                 />
             </a>
         </svelte:fragment>
@@ -83,7 +83,7 @@
                 </a>
             {:else}
                 <button
-                    class="btn variant-ringed-primary"
+                    class="variant-ringed-primary btn"
                     on:click={() => redirectToLogin()}>Anmelden</button
                 >
             {/if}
@@ -105,7 +105,7 @@
             </TabAnchor>
         </TabGroup>
     {/if}
-    <div class="p-4 h-fit">
+    <div class="h-fit p-4">
         <slot />
     </div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
     <title>Voycar</title>
 </svelte:head>
 
-<div class="flex flex-col justify-center items-center h-[70vh]">
+<div class="flex h-[70vh] flex-col items-center justify-center">
     <div class="border-md rounded-md bg-surface-700 p-4">
         <h1 class="h1 text-center">Willkommen bei Voycar</h1>
     </div>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -20,10 +20,10 @@
 </script>
 
 <!-- Login page -->
-<div class="flex flex-col justify-center items-center mt-4">
+<div class="mt-4 flex flex-col items-center justify-center">
     <h1 class="h2 mb-8">Bei Voycar anmelden</h1>
-    <div class="w-96 justify-center items-center space-y-4">
-        <form class="p-4 border-2 rounded-md border-secondary-500 space-y-3">
+    <div class="w-96 items-center justify-center space-y-4">
+        <form class="space-y-3 rounded-md border-2 border-secondary-500 p-4">
             <!-- Email field -->
             <label class="label" for="email_input">
                 <span>Email</span>
@@ -39,7 +39,7 @@
                 <span>Passwort</span>
             </label>
             <div
-                class="relative input-group input-group-divider grid-cols-[auto_1fr_auto]"
+                class="input-group input-group-divider relative grid-cols-[auto_1fr_auto]"
             >
                 <input
                     class="w-72 {passwordIndicator}"
@@ -48,7 +48,7 @@
                     placeholder="Dein super sicheres Passwort 😉"
                 />
                 <button
-                    class="right-0 leading-5 variant-filled-secondary"
+                    class="variant-filled-secondary right-0 leading-5"
                     on:click={() => (showPassword = !showPassword)}
                 >
                     {#if showPassword}
@@ -69,12 +69,12 @@
 
             <!-- Login button -->
             <div class="flex flex-col items-center">
-                <button class="btn variant-filled-primary w-full"
+                <button class="variant-filled-primary btn w-full"
                     >Anmelden</button
                 >
             </div>
             <!-- Password reset -->
-            <div class="flex justify-center items-center">
+            <div class="flex items-center justify-center">
                 <a class="text-sm text-tertiary-600" href="/forgotPassword"
                     >Passwort vergessen?</a
                 >
@@ -82,7 +82,7 @@
         </form>
         <!-- Sing up for new account link -->
         <div
-            class="flex flex-col-2 items-center justify-between border-2 rounded-md border-secondary-500 p-4"
+            class="flex-col-2 flex items-center justify-between rounded-md border-2 border-secondary-500 p-4"
         >
             <p>Neu bei Voycar?</p>
             <a class="text-tertiary-500" href="/register"

--- a/src/routes/user/+page.svelte
+++ b/src/routes/user/+page.svelte
@@ -67,11 +67,11 @@
         <LoggedInUser {personalData}></LoggedInUser>
     {:catch error}
         <!-- Display on error -->
-        <p class="text-center h3">
+        <p class="h3 text-center">
             Ihr Nutzerkonto konnte nicht gefunden werden. Sie werden auf die
             Startseite zurückgeleitet!
         </p>
-        <p class="text-center h3">
+        <p class="h3 text-center">
             Falls sie nicht automatisch weitergeleitet werden klicken sie
             <a href="/" class="text-primary-500 underline">hier</a>
             um zur Startseite zurückzukehren!

--- a/src/routes/user/loggedInUser.svelte
+++ b/src/routes/user/loggedInUser.svelte
@@ -40,7 +40,7 @@
 </svelte:head>
 <div>
     <div class="pb-4">
-        <p class="text-xl font-semibold pl-2">
+        <p class="pl-2 text-xl font-semibold">
             <!-- Greeting -->
             Hallo {personalData.firstName}
             {personalData.lastName}
@@ -50,7 +50,7 @@
         <!-- Accordion for user data-->
         <Accordion>
             <!-- Personal details tab -->
-            <AccordionItem class="border-2 rounded-md border-primary-500">
+            <AccordionItem class="rounded-md border-2 border-primary-500">
                 <svelte:fragment slot="summary"
                     >Persönliche Informationen</svelte:fragment
                 >
@@ -68,7 +68,7 @@
             </AccordionItem>
             <!-- Payment information tab -->
             {#if userPaymentInfoID != null}
-                <AccordionItem class="border-2 rounded-md border-secondary-500">
+                <AccordionItem class="rounded-md border-2 border-secondary-500">
                     <svelte:fragment slot="summary"
                         >Zahlungsinformation</svelte:fragment
                     >
@@ -87,7 +87,7 @@
             {/if}
             <!-- Subscription plan information -->
             {#if userSubPlanID != null}
-                <AccordionItem class="border-2 rounded-md border-tertiary-500">
+                <AccordionItem class="rounded-md border-2 border-tertiary-500">
                     <svelte:fragment slot="summary">Tarif</svelte:fragment>
                     <svelte:fragment slot="content">
                         <!-- Inject user plan data svelte component -->
@@ -108,13 +108,13 @@
     <div class="relative pt-4">
         <button
             type="button"
-            class="btn bg-gradient-to-br variant-filled-error absolute right-0"
+            class="variant-filled-error btn absolute right-0 bg-gradient-to-br"
             use:popup={popupClick}
         >
             Kontolöschung beantragen
         </button>
         <!-- Floating ui popup to confirm account deletion -->
-        <div class="card p-2 bg-secondary-500" data-popup="popupClick">
+        <div class="card bg-secondary-500 p-2" data-popup="popupClick">
             <aside class="alert variant-filled-warning">
                 <div class="alert-message">
                     <h3 class="h3">Kontolöschung bestätigen</h3>
@@ -124,12 +124,12 @@
                 <div class="alert-actions">
                     <button
                         type="button"
-                        class="btn variant-filled"
+                        class="variant-filled btn"
                         on:click={confirmDeletion}>Bestätigen</button
                     >
                 </div>
             </aside>
-            <div class="arrow variant-filled-primary" />
+            <div class="variant-filled-primary arrow" />
         </div>
     </div>
 </div>

--- a/src/routes/user/userComponents/userData.svelte
+++ b/src/routes/user/userComponents/userData.svelte
@@ -23,7 +23,7 @@
                             <label class="label">
                                 <input
                                     disabled={!formEditEnabled}
-                                    class="input form--disabled variant-form-material"
+                                    class="form--disabled input variant-form-material"
                                     type="text"
                                     name="inputField"
                                     placeholder={userInfo[i]}
@@ -41,7 +41,7 @@
 <div dir="rtl">
     <button
         type="button"
-        class="btn btn-md variant-filled-warning"
+        class="variant-filled-warning btn btn-md"
         on:click={() => (formEditEnabled = !formEditEnabled)}
     >
         Bearbeiten
@@ -51,7 +51,7 @@
         <img src="/editIcon.svg" alt="edit icon" />
     </button>
     {#if formEditEnabled}
-        <button type="button" class="btn btn-md variant-filled-success">
+        <button type="button" class="variant-filled-success btn btn-md">
             <!-- ToDo logic for update button-->
             Aktualisieren
             <img src="/saveIcon.svg" alt="save icon" />

--- a/src/routes/user/userComponents/userPaymentData.svelte
+++ b/src/routes/user/userComponents/userPaymentData.svelte
@@ -45,13 +45,13 @@
     </div>
     <!-- Buttons -->
     <div dir="rtl" class="height-auto">
-        <button type="button" class="btn btn-md variant-filled-error">
+        <button type="button" class="variant-filled-error btn btn-md">
             <!-- ToDo logic for delete button -->
             Löschen
         </button>
         <button
             type="button"
-            class="btn btn-md variant-filled-warning"
+            class="variant-filled-warning btn btn-md"
             on:click={() => (formEditEnabled = !formEditEnabled)}
         >
             Bearbeiten
@@ -61,7 +61,7 @@
             <img src="/editIcon.svg" alt="edit icon" />
         </button>
         {#if formEditEnabled}
-            <button type="button" class="btn btn-md variant-filled-success">
+            <button type="button" class="variant-filled-success btn btn-md">
                 <!-- ToDo logic for update button -->
                 Aktualisieren
                 <img src="/saveIcon.svg" alt="save icon" />

--- a/src/routes/user/userPageLoadingPlaceholders.svelte
+++ b/src/routes/user/userPageLoadingPlaceholders.svelte
@@ -1,9 +1,9 @@
 <div class="relative pt-1">
-    <div class="placeholder animate-pulse w-60 h-8 mb-4" />
+    <div class="placeholder mb-4 h-8 w-60 animate-pulse" />
     <div class="space-y-2">
         {#each { length: 3 } as _}
-            <div class="placeholder animate-pulse h-10"></div>
+            <div class="placeholder h-10 animate-pulse"></div>
         {/each}
     </div>
-    <div class="placeholder animate-pulse absolute w-60 h-12 right-0 mt-2" />
+    <div class="placeholder absolute right-0 mt-2 h-12 w-60 animate-pulse" />
 </div>


### PR DESCRIPTION
[User story 167](https://tree.taiga.io/project/julius-boettger-voycar/us/167)

Mit dem Prettier plugin werden tailwind Klassen jetzt bei einem format automatisch sortiert. Macht es deutlich einheitlicher. 