### PR TITLE
us-204 Bei Redirect nach Login direkt richtige Seite zeigen

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -46,7 +46,7 @@
     }
 
     // Redirects to url and reloads new layout content
-    function redirectAndReloadPage(url){
+    function redirectAndReloadPage(url) {
         window.location.href = url;
     }
 

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,16 +1,8 @@
 <script>
-    // Framework imports
-    import { getToastStore } from "@skeletonlabs/skeleton";
-
     // Import backend urls
     import { urls, validateEmail, tryFetchingRestricted } from "$lib/util.js";
 
-    import { goto } from "$app/navigation";
-
     // Definitions
-    // Constants
-    const toastStore = getToastStore();
-
     // Enums
     const btnIcon = {
         locked: "🔐",
@@ -21,14 +13,6 @@
         none: "",
         warning: "!border-warning-400",
         error: "!border-error-600",
-    };
-
-    // Toast Settings
-    const toast = {
-        message: "Sie wurden erfolgreich angemeldet",
-        hideDismiss: true, // Hide the dismiss button on toast
-        timeout: 3000, // Auto dismiss toast after 3 seconds
-        background: "variant-filled-secondary",
     };
 
     // Variables
@@ -61,6 +45,11 @@
         }
     }
 
+    // Redirects to url and reloads new layout content
+    function redirectAndReloadPage(url){
+        window.location.href = url;
+    }
+
     async function fetchLogin(email, password) {
         try {
             const mybody = {
@@ -73,10 +62,9 @@
                 mybody,
             );
             if (response.ok) {
-                toastStore.trigger(toast);
                 // Login sucessful
                 somethingWrong = false;
-                goto("/");
+                redirectAndReloadPage("/");
             } else {
                 // Login failed on the backend side e.g. because credentials didn't match or account doesn't exists
                 throw new Error("Login failed");


### PR DESCRIPTION
[User story 204](https://tree.taiga.io/project/julius-boettger-voycar/us/204)
Nach dem Login wird jetzt die Seite neu geladen, damit die TabBar und alle anderen Elemente, die neu geladen werden müssen, sichtbar werden. Der Toast wurde dafür entfernt. Den brauch man mMn auch nicht mehr wirklich, weil man ja erkennt, dass man erfolgreich angemeldet wurde, wenn man keinen Fehler bekommt und einem neue Elemente zur Verfügung stehen.