### PR TITLE
us-203 Logout implementieren

### DIFF
--- a/src/routes/pageHeader.svelte
+++ b/src/routes/pageHeader.svelte
@@ -15,6 +15,19 @@
         goto("/login");
     }
 
+    async function logout(){
+        try {
+            // Fetch backend to check if user is signed in
+            const response = await tryFetchingRestricted(urls.post.logout, "POST");
+            if (response.ok) {
+                loggedIn = false;
+            } else {
+                loggedIn = true;
+            }
+        } catch (err) {
+            console.log(err);
+        }
+    }
     // Runs as soon as the component is mounted
     onMount(async () => {
         try {
@@ -52,10 +65,10 @@
         </svelte:fragment>
         <svelte:fragment slot="trail">
             {#if loggedIn}
-                <a href="/user">
-                    <!-- User icon -->
-                    <img src="/userIcon.svg" alt="user icon" />
-                </a>
+                <button
+                    class="variant-ringed-error btn"
+                    on:click={logout}>Abmelden</button
+                >
             {:else}
                 <button
                     class="variant-ringed-primary btn"

--- a/src/routes/pageHeader.svelte
+++ b/src/routes/pageHeader.svelte
@@ -54,7 +54,7 @@
         slotTrail="place-content-end"
     >
         <svelte:fragment slot="lead">
-            <div/>
+            <div />
         </svelte:fragment>
         <svelte:fragment slot="default">
             <a href="/">

--- a/src/routes/pageHeader.svelte
+++ b/src/routes/pageHeader.svelte
@@ -68,7 +68,7 @@
         </svelte:fragment>
         <svelte:fragment slot="trail">
             {#if loggedIn}
-                <button class="variant-ringed-error btn" on:click={logout}
+                <button class="variant-ringed-surface btn" on:click={logout}
                     >Abmelden</button
                 >
             {:else}

--- a/src/routes/pageHeader.svelte
+++ b/src/routes/pageHeader.svelte
@@ -15,10 +15,13 @@
         goto("/login");
     }
 
-    async function logout(){
+    async function logout() {
         try {
             // Fetch backend to check if user is signed in
-            const response = await tryFetchingRestricted(urls.post.logout, "POST");
+            const response = await tryFetchingRestricted(
+                urls.post.logout,
+                "POST",
+            );
             if (response.ok) {
                 loggedIn = false;
             } else {
@@ -65,9 +68,8 @@
         </svelte:fragment>
         <svelte:fragment slot="trail">
             {#if loggedIn}
-                <button
-                    class="variant-ringed-error btn"
-                    on:click={logout}>Abmelden</button
+                <button class="variant-ringed-error btn" on:click={logout}
+                    >Abmelden</button
                 >
             {:else}
                 <button

--- a/src/routes/pageHeader.svelte
+++ b/src/routes/pageHeader.svelte
@@ -54,7 +54,7 @@
         slotTrail="place-content-end"
     >
         <svelte:fragment slot="lead">
-            <img src="/menuIcon.svg" alt="menu icon" />
+            <div/>
         </svelte:fragment>
         <svelte:fragment slot="default">
             <a href="/">


### PR DESCRIPTION
[User story 203](https://tree.taiga.io/project/julius-boettger-voycar/us/203)
Im Header einen Logout Button hinzugefügt, dabei wurde das User-Icon ersetzt, da die Kontoseite nach us-168 (siehe #20 ) über die TabBar Navigation erreicht werden kann, und die Seite jetzt konsistenter aussieht.
Außerdem wurde das Hamburger-Menu Icon entfernt, da es keine Funktion besitzt. Dies muss durch ein leeres div ersetzt werden, da sonst das Bild nicht mehr mittig und die Buttons nicht mehr rechts sind.   