### PR TITLE
us-213 Hilfsmethode zum Übersetzen Abo Namen

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -87,5 +87,5 @@ const planNames = {
     exclusive: "Exklusiv",
 };
 export function translatePlanName(backendName) {
-    return planNames[backendName.toLowerCase()];
+    return planNames[backendName.toLowerCase()] ?? backendName;
 }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -79,3 +79,13 @@ export async function tryFetchingRestricted(url, method, body) {
 export async function tryFetchingPublic(url, method, body) {
     return await tryFetching(url, method, body, false);
 }
+
+// Formatting backend information to Frontend Text
+const planNames = {
+    basic: "Basic",
+    reduced: "Ermäßigt",
+    exclusive: "Exklusiv",
+};
+export function translatePlanName(backendName) {
+    return planNames[backendName.toLowerCase()];
+}

--- a/src/routes/user/userComponents/userPlanData.svelte
+++ b/src/routes/user/userComponents/userPlanData.svelte
@@ -4,7 +4,7 @@
     import { onMount } from "svelte";
 
     // Import backend urls and fetch function
-    import { urls, tryFetchingRestricted } from "$lib/util.js";
+    import { urls, tryFetchingRestricted, translatePlanName } from "$lib/util.js";
 
     // Definitions
     const toastStore = getToastStore();
@@ -126,7 +126,7 @@
                 bind:this={planReference}
             >
                 {#each planData as plan}
-                    <option value={plan.id}>{plan.name}</option>
+                    <option value={plan.id}>{translatePlanName(plan.name)}</option>
                 {/each}
             </select>
         </div>

--- a/src/routes/user/userComponents/userPlanData.svelte
+++ b/src/routes/user/userComponents/userPlanData.svelte
@@ -118,7 +118,7 @@
         <div class="flex flex-row space-x-2">
             <p class="self-center">Aktueller Tarif:</p>
             <select
-                class="select w-2/4"
+                class="select w-2/4 capitalize"
                 size="1"
                 id="selectField"
                 value={resolvePlanNameToPlanId(personalData.planName)}


### PR DESCRIPTION
[User story 231](https://tree.taiga.io/project/julius-boettger-voycar/us/213)

Ich glaube den ersten Buchstaben großzuschreiben, ist schöner über CSS Klassen zu machen, als über die JS Funktion. Die Übersetzung ist jetzt drinne und direkt verwendet.
![grafik](https://github.com/solid-stack-solutions/voycar-frontend/assets/58894308/d03dcfd0-9b0f-4164-9d6f-e5f777f7c2ec)
